### PR TITLE
[FIX][ADD] l10n_mx_edi_decimal_fix: use Decimal ROUND_HALF_UP and add unit tests

### DIFF
--- a/l10n_mx_edi_decimal_fix/data/cfdi.xml
+++ b/l10n_mx_edi_decimal_fix/data/cfdi.xml
@@ -8,21 +8,15 @@
             position="attributes"
         >
             <attribute name="t-att-SubTotal">
-                format_float(
-                    float_round(subtotal, precision_digits=2),
-                    precision=2
-                )
+                format_float(subtotal, precision=2)
             </attribute>
             <attribute name="t-att-Descuento">
-                format_float(
-                    float_round(descuento, precision_digits=2),
-                    precision=2
-                ) if descuento else False
+                format_float(descuento, precision=2) if descuento else False
             </attribute>
             <attribute name="t-att-Total">
                 format_float(
-                    float_round(subtotal, precision_digits=2) -
-                    (float_round(descuento, precision_digits=2) if descuento else 0) +
+                    float(format_float(subtotal, precision=2)) -
+                    (float(format_float(descuento, precision=2)) if descuento else 0) +
                     (float(format_float(total_impuestos_trasladados, precision=2)) if total_impuestos_trasladados else 0) -
                     (float(format_float(total_impuestos_retenidos, precision=2)) if total_impuestos_retenidos else 0),
                     precision=2
@@ -55,7 +49,9 @@
             //*[local-name()='Retencion' and namespace-uri()='http://www.sat.gob.mx/cfd/4']"
             position="attributes"
         >
-            <attribute name="t-att-Importe">format_float(tax_values['importe'], precision=2)</attribute>
+            <attribute
+                name="t-att-Importe"
+            >format_float(tax_values['importe'], precision=2)</attribute>
         </xpath>
 
         <!-- cfdi:Impuestos/cfdi:Traslados//cfdi:Traslado -->
@@ -69,8 +65,10 @@
         >
             <attribute
                 name="t-att-Base"
-            >format_float(float_round(tax_values['base'], precision_digits=2), precision=2)</attribute>
-            <attribute name="t-att-Importe">format_float(tax_values['importe'], precision=2)</attribute>
+            >format_float(tax_values['base'], precision=2)</attribute>
+            <attribute
+                name="t-att-Importe"
+            >format_float(tax_values['importe'], precision=2)</attribute>
         </xpath>
 
     </template>

--- a/l10n_mx_edi_decimal_fix/models/l10n_mx_edi_document.py
+++ b/l10n_mx_edi_decimal_fix/models/l10n_mx_edi_document.py
@@ -1,6 +1,7 @@
+from decimal import ROUND_HALF_UP, Decimal
+
 from odoo import api, models
-from odoo.tools.float_utils import float_is_zero, float_round
-from decimal import Decimal, ROUND_HALF_UP
+from odoo.tools.float_utils import float_round
 
 
 class L10nMxEdiDocument(models.Model):
@@ -23,24 +24,27 @@ class L10nMxEdiDocument(models.Model):
             if amount is False:
                 amount = 0
 
-            qty = Decimal('1.' + ('0' * precision))
+            qty = Decimal("1." + ("0" * precision))
             value = Decimal(str(amount))
 
-            return format(
-                value.quantize(qty, rounding=ROUND_HALF_UP),
-                f'.{precision}f'
-            )
+            return format(value.quantize(qty, rounding=ROUND_HALF_UP), f".{precision}f")
 
-        cfdi_values.update({
-            'format_float': format_float,
-        })
+        cfdi_values.update(
+            {
+                "format_float": format_float,
+            }
+        )
         return res
 
     @api.model
     def _get_company_cfdi_values(self, company):
         res = super()._get_company_cfdi_values(company)
         if self._context.get("params", {}).get("model") == "account.move":
-            move = self.env["account.move"].browse(self._context.get("params", {}).get("id"))
-            if move and move.journal_id.l10n_mx_address_issued_id != res.get("issued_address"):
+            move = self.env["account.move"].browse(
+                self._context.get("params", {}).get("id")
+            )
+            if move and move.journal_id.l10n_mx_address_issued_id != res.get(
+                "issued_address"
+            ):
                 res["issued_address"] = move.journal_id.l10n_mx_address_issued_id
         return res

--- a/l10n_mx_edi_decimal_fix/models/l10n_mx_edi_document.py
+++ b/l10n_mx_edi_decimal_fix/models/l10n_mx_edi_document.py
@@ -1,23 +1,17 @@
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import ROUND_DOWN, ROUND_HALF_UP, Decimal
 
 from odoo import api, models
-from odoo.tools.float_utils import float_round
 
 
 class L10nMxEdiDocument(models.Model):
     _inherit = "l10n_mx_edi.document"
 
     @api.model
-    def _add_base_cfdi_values(self, cfdi_values):
-        cfdi_values["float_round"] = float_round
-        return super()._add_base_cfdi_values(cfdi_values)
-
-    @api.model
     def _add_currency_cfdi_values(self, cfdi_values, currency):
         res = super()._add_currency_cfdi_values(cfdi_values, currency)
         currency_precision = currency.l10n_mx_edi_decimal_places
 
-        def format_float(amount, precision=currency_precision):
+        def format_float(amount, precision=2):
             if amount is None:
                 return None
 
@@ -32,9 +26,46 @@ class L10nMxEdiDocument(models.Model):
         cfdi_values.update(
             {
                 "format_float": format_float,
+                "currency_precision": currency_precision,
             }
         )
         return res
+
+    @api.model
+    def _get_post_fix_tax_amounts_map(
+        self, base_amount, tax_amount, tax_rate, precision_digits
+    ):
+        qty = Decimal("1." + ("0" * precision_digits))
+        d_base = Decimal(str(base_amount))
+        d_tax = Decimal(str(tax_amount))
+        d_rate = Decimal(str(tax_rate))
+
+        mismatch = (d_base * d_rate - d_tax).copy_abs().quantize(
+            qty, rounding=ROUND_DOWN
+        )
+        if mismatch == Decimal("0"):
+            # No arithmetic inconsistency at precision_digits — return values
+            # unchanged so that delta_base_amount is exactly 0.0. Returning a
+            # float-rounded new_base would produce a different IEEE-754
+            # double than base_amount, generating a sub-epsilon negative delta
+            # that, when added to gross_price_subtotal (which may be a third
+            # distinct double), pushes importe below the ROUND_HALF_UP midpoint.
+            return {
+                "new_base_amount": base_amount,
+                "new_tax_amount": tax_amount,
+                "delta_base_amount": 0.0,
+                "delta_tax_amount": 0.0,
+            }
+
+        d_total = d_base + d_tax
+        new_base = float((d_total / (1 + d_rate)).quantize(qty, rounding=ROUND_HALF_UP))
+        new_tax = float(d_total - Decimal(str(new_base)))
+        return {
+            "new_base_amount": new_base,
+            "new_tax_amount": new_tax,
+            "delta_base_amount": new_base - base_amount,
+            "delta_tax_amount": new_tax - tax_amount,
+        }
 
     @api.model
     def _get_company_cfdi_values(self, company):

--- a/l10n_mx_edi_decimal_fix/pyproject.toml
+++ b/l10n_mx_edi_decimal_fix/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/l10n_mx_edi_decimal_fix/tests/__init__.py
+++ b/l10n_mx_edi_decimal_fix/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_decimal_fix

--- a/l10n_mx_edi_decimal_fix/tests/common.py
+++ b/l10n_mx_edi_decimal_fix/tests/common.py
@@ -1,0 +1,22 @@
+from odoo.addons.l10n_mx_edi.tests.common import TestMxEdiCommon
+
+
+class TestDecimalFixCommon(TestMxEdiCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.mxn_currency = cls.env.ref("base.MXN")
+        cls.mxn_currency.sudo().write(
+            {
+                "l10n_mx_edi_decimal_places": 6,
+                "rounding": 0.000001,
+            }
+        )
+        cls.usd_currency = cls.env.ref("base.USD")
+        cls.usd_currency.sudo().write(
+            {
+                "l10n_mx_edi_decimal_places": 6,
+                "rounding": 0.000001,
+            }
+        )

--- a/l10n_mx_edi_decimal_fix/tests/test_decimal_fix.py
+++ b/l10n_mx_edi_decimal_fix/tests/test_decimal_fix.py
@@ -17,6 +17,12 @@ class TestDecimalFix(TestDecimalFixCommon):
     below the exact value.  float_round(..., precision_digits=2) would then produce
     41753.11 instead of the correct ROUND_HALF_UP result of 41753.12, causing the PAC
     to reject the CFDI due to arithmetic inconsistency.
+
+    With round_globally, _get_post_fix_tax_amounts_map uses float_round to compute
+    new_base_amount, which can shift the base by ±1 unit at 6dp (e.g. 41753.115 →
+    41753.114).  That delta propagates to cfdi_line_values['importe'] and then to
+    cfdi_values['subtotal'], breaking the 2dp rounding.  The fix overrides
+    _get_post_fix_tax_amounts_map to use Decimal ROUND_HALF_UP throughout.
     """
 
     # -------------------------------------------------------------------------
@@ -56,188 +62,205 @@ class TestDecimalFix(TestDecimalFixCommon):
 
     # -------------------------------------------------------------------------
     # Case 1: MXN 6 decimals — qty=0.5, price=83,506.23 — no discount
+    # Both round_per_line and round_globally must produce identical CFDI amounts.
     # -------------------------------------------------------------------------
 
     def test_half_up_rounding_subtotal(self):
         """
         SubTotal = 0.5 × 83506.23 = 41753.115 → ROUND_HALF_UP to 2 dp = 41753.12.
-        The bug was that float_round() rounded this to 41753.11 (HALF-EVEN or fp error),
-        while format_float() via Decimal correctly gives 41753.12.
+        Tested for both round_per_line and round_globally.
         """
-        with self.mx_external_setup(self.frozen_today):
-            invoice = self._create_invoice(
-                currency_id=self.mxn_currency.id,
-                invoice_line_ids=[
-                    Command.create(
-                        {
-                            "product_id": self.product.id,
-                            "quantity": 0.5,
-                            "price_unit": 83506.23,
-                            "tax_ids": [Command.set(self.tax_16.ids)],
-                        }
-                    ),
-                ],
-            )
 
-            with self.with_mocked_pac_sign_success():
-                invoice._l10n_mx_edi_cfdi_invoice_try_send()
+        def run(rounding_method):
+            with self.mx_external_setup(self.frozen_today):
+                invoice = self._create_invoice(
+                    currency_id=self.mxn_currency.id,
+                    invoice_line_ids=[
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 0.5,
+                                "price_unit": 83506.23,
+                                "tax_ids": [Command.set(self.tax_16.ids)],
+                            }
+                        ),
+                    ],
+                )
 
-            document = self._get_invoice_document(invoice)
-            self.assertTrue(document, "CFDI invoice document was not created")
+                with self.with_mocked_pac_sign_success():
+                    invoice._l10n_mx_edi_cfdi_invoice_try_send()
 
-            cfdi = self._get_cfdi_tree(document)
-            self._assert_comprobante_amounts(
-                cfdi, subtotal="41753.12", total="48433.62"
-            )
-            self._assert_aggregate_traslado(cfdi, base="41753.12", importe="6680.50")
+                document = self._get_invoice_document(invoice)
+                self.assertTrue(
+                    document,
+                    f"CFDI invoice document not created ({rounding_method})",
+                )
+
+                cfdi = self._get_cfdi_tree(document)
+                self._assert_comprobante_amounts(
+                    cfdi, subtotal="41753.12", total="48433.62"
+                )
+                self._assert_aggregate_traslado(
+                    cfdi, base="41753.12", importe="6680.50"
+                )
+
+        self._test_cfdi_rounding(run)
 
     # -------------------------------------------------------------------------
-    # Case 2: PPD payment after case 1 invoice
+    # Case 2: PPD payment after case 1 invoice — both rounding methods
     # -------------------------------------------------------------------------
 
     def test_half_up_rounding_payment(self):
         """
         PPD payment for the 41753.12 + IVA invoice.
         Validates ImpSaldoAnt, ImpPagado and ImpSaldoInsoluto are coherent at 2 dp.
+        Tested for both round_per_line and round_globally.
         """
-        with self.mx_external_setup(self.frozen_today):
-            invoice = self._create_invoice(
-                currency_id=self.mxn_currency.id,
-                invoice_line_ids=[
-                    Command.create(
-                        {
-                            "product_id": self.product.id,
-                            "quantity": 0.5,
-                            "price_unit": 83506.23,
-                            "tax_ids": [Command.set(self.tax_16.ids)],
-                        }
-                    ),
-                ],
-            )
-            with self.with_mocked_pac_sign_success():
-                invoice._l10n_mx_edi_cfdi_invoice_try_send()
 
-            invoice_doc = self._get_invoice_document(invoice)
-            self.assertTrue(invoice_doc)
+        def run(rounding_method):
+            with self.mx_external_setup(self.frozen_today):
+                invoice = self._create_invoice(
+                    currency_id=self.mxn_currency.id,
+                    invoice_line_ids=[
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 0.5,
+                                "price_unit": 83506.23,
+                                "tax_ids": [Command.set(self.tax_16.ids)],
+                            }
+                        ),
+                    ],
+                )
+                with self.with_mocked_pac_sign_success():
+                    invoice._l10n_mx_edi_cfdi_invoice_try_send()
 
-            payment = self._create_payment(invoice)
-            with self.with_mocked_pac_sign_success():
-                payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
+                invoice_doc = self._get_invoice_document(invoice)
+                self.assertTrue(invoice_doc)
 
-            pay_doc = self._get_payment_document(payment.move_id)
-            self.assertTrue(pay_doc, "CFDI payment document was not created")
+                payment = self._create_payment(invoice)
+                with self.with_mocked_pac_sign_success():
+                    payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
 
-            pay_cfdi = self._get_cfdi_tree(pay_doc)
-            ns_pago = "http://www.sat.gob.mx/Pagos20"
+                pay_doc = self._get_payment_document(payment.move_id)
+                self.assertTrue(
+                    pay_doc,
+                    f"CFDI payment document not created ({rounding_method})",
+                )
 
-            docto_list = pay_cfdi.findall(f".//{{{ns_pago}}}DoctoRelacionado")
-            self.assertTrue(docto_list, "No DoctoRelacionado in payment CFDI")
-            docto = docto_list[0]
-            imp_saldo_ant = docto.get("ImpSaldoAnt")
-            imp_pagado = docto.get("ImpPagado")
-            imp_saldo_insoluto = docto.get("ImpSaldoInsoluto")
+                pay_cfdi = self._get_cfdi_tree(pay_doc)
+                ns_pago = "http://www.sat.gob.mx/Pagos20"
 
-            # After fixing the invoice CFDI, the stored invoice total is coherent
-            # and the payment complement must reflect the 2-decimal rounded amount.
-            self.assertEqual(imp_saldo_insoluto, "0.00")
-            self.assertEqual(imp_saldo_ant, imp_pagado)
+                docto_list = pay_cfdi.findall(f".//{{{ns_pago}}}DoctoRelacionado")
+                self.assertTrue(docto_list, "No DoctoRelacionado in payment CFDI")
+                docto = docto_list[0]
+                imp_saldo_ant = docto.get("ImpSaldoAnt")
+                imp_pagado = docto.get("ImpPagado")
+                imp_saldo_insoluto = docto.get("ImpSaldoInsoluto")
 
-            # The paid amount must be positive and have at most 2 decimal places.
-            self.assertRegex(imp_pagado, r"^\d+\.\d{2}$")
+                self.assertEqual(imp_saldo_insoluto, "0.00")
+                self.assertEqual(imp_saldo_ant, imp_pagado)
+                self.assertRegex(imp_pagado, r"^\d+\.\d{2}$")
+
+        self._test_cfdi_rounding(run)
 
     # -------------------------------------------------------------------------
-    # Case 3: USD 6 decimals — same qty/price, payment in MXN
+    # Case 3: USD 6 decimals — same qty/price, payment in MXN — both methods
     # -------------------------------------------------------------------------
 
     def test_half_up_usd_multidivisa(self):
         """
         Invoice in USD (6 decimal places) for qty=0.5, price=83506.23.
         Then a payment in MXN to validate the currency conversion path.
+        Tested for both round_per_line and round_globally.
         """
         rate = 1.0 / 17.0  # 1 USD = 17 MXN
         self.setup_rates(self.usd_currency, (self.frozen_today, rate))
 
-        with self.mx_external_setup(self.frozen_today):
-            invoice = self._create_invoice(
-                currency_id=self.usd_currency.id,
-                invoice_line_ids=[
-                    Command.create(
-                        {
-                            "product_id": self.product.id,
-                            "quantity": 0.5,
-                            "price_unit": 83506.23,
-                            "tax_ids": [Command.set(self.tax_16.ids)],
-                        }
-                    ),
-                ],
-            )
-            with self.with_mocked_pac_sign_success():
-                invoice._l10n_mx_edi_cfdi_invoice_try_send()
+        def run(rounding_method):
+            with self.mx_external_setup(self.frozen_today):
+                invoice = self._create_invoice(
+                    currency_id=self.usd_currency.id,
+                    invoice_line_ids=[
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 0.5,
+                                "price_unit": 83506.23,
+                                "tax_ids": [Command.set(self.tax_16.ids)],
+                            }
+                        ),
+                    ],
+                )
+                with self.with_mocked_pac_sign_success():
+                    invoice._l10n_mx_edi_cfdi_invoice_try_send()
 
-            inv_doc = self._get_invoice_document(invoice)
-            self.assertTrue(
-                inv_doc, "CFDI invoice document was not created for USD invoice"
-            )
+                inv_doc = self._get_invoice_document(invoice)
+                self.assertTrue(
+                    inv_doc,
+                    f"CFDI invoice document not created for USD ({rounding_method})",
+                )
 
-            inv_cfdi = self._get_cfdi_tree(inv_doc)
-            self.assertEqual(inv_cfdi.get("Moneda"), "USD")
-            # SubTotal must be ROUND_HALF_UP of 41753.115 to 2 dp = 41753.12
-            self._assert_comprobante_amounts(
-                inv_cfdi, subtotal="41753.12", total="48433.62"
-            )
+                inv_cfdi = self._get_cfdi_tree(inv_doc)
+                self.assertEqual(inv_cfdi.get("Moneda"), "USD")
+                self._assert_comprobante_amounts(
+                    inv_cfdi, subtotal="41753.12", total="48433.62"
+                )
 
-        with self.mx_external_setup(self.frozen_today):
-            payment = self._create_payment(
-                invoice,
-                currency_id=self.mxn_currency.id,
-            )
-            with self.with_mocked_pac_sign_success():
-                payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
+            with self.mx_external_setup(self.frozen_today):
+                payment = self._create_payment(
+                    invoice,
+                    currency_id=self.mxn_currency.id,
+                )
+                with self.with_mocked_pac_sign_success():
+                    payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
 
-            pay_doc = self._get_payment_document(payment.move_id)
-            self.assertTrue(
-                pay_doc, "CFDI payment document was not created for USD→MXN"
-            )
+                pay_doc = self._get_payment_document(payment.move_id)
+                self.assertTrue(
+                    pay_doc,
+                    f"CFDI payment document not created for USD→MXN ({rounding_method})",
+                )
+
+        self._test_cfdi_rounding(run)
 
     # -------------------------------------------------------------------------
-    # Case 4: MXN 6 decimals — same qty/price with 10% discount
+    # Case 4: MXN 6 decimals — same qty/price with 10% discount — both methods
     # -------------------------------------------------------------------------
 
     def test_half_up_rounding_with_discount(self):
         """
         10% discount on same line.
         SubTotal (gross) = 41753.12, Descuento = 4175.31 (ROUND_HALF_UP of 4175.3115).
-        Validates that the Descuento attribute is correctly included and Total is
-        coherent.
+        Tested for both round_per_line and round_globally.
         """
-        with self.mx_external_setup(self.frozen_today):
-            invoice = self._create_invoice(
-                currency_id=self.mxn_currency.id,
-                invoice_line_ids=[
-                    Command.create(
-                        {
-                            "product_id": self.product.id,
-                            "quantity": 0.5,
-                            "price_unit": 83506.23,
-                            "discount": 10.0,
-                            "tax_ids": [Command.set(self.tax_16.ids)],
-                        }
-                    ),
-                ],
-            )
-            with self.with_mocked_pac_sign_success():
-                invoice._l10n_mx_edi_cfdi_invoice_try_send()
 
-            document = self._get_invoice_document(invoice)
-            self.assertTrue(document)
+        def run(_rounding_method):
+            with self.mx_external_setup(self.frozen_today):
+                invoice = self._create_invoice(
+                    currency_id=self.mxn_currency.id,
+                    invoice_line_ids=[
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 0.5,
+                                "price_unit": 83506.23,
+                                "discount": 10.0,
+                                "tax_ids": [Command.set(self.tax_16.ids)],
+                            }
+                        ),
+                    ],
+                )
+                with self.with_mocked_pac_sign_success():
+                    invoice._l10n_mx_edi_cfdi_invoice_try_send()
 
-            cfdi = self._get_cfdi_tree(document)
-            # SubTotal is gross (before discount) = ROUND_HALF_UP(41753.115) = 41753.12
-            self.assertEqual(cfdi.get("SubTotal"), "41753.12")
-            # Descuento = ROUND_HALF_UP(4175.3115) = 4175.31
-            self.assertEqual(cfdi.get("Descuento"), "4175.31")
-            # Total must be a valid 2-decimal number
-            self.assertRegex(cfdi.get("Total"), r"^\d+\.\d{2}$")
-            # Total = SubTotal - Descuento + IVA → must be positive
-            total = float(cfdi.get("Total"))
-            self.assertGreater(total, 0.0)
+                document = self._get_invoice_document(invoice)
+                self.assertTrue(document)
+
+                cfdi = self._get_cfdi_tree(document)
+                self.assertEqual(cfdi.get("SubTotal"), "41753.12")
+                self.assertEqual(cfdi.get("Descuento"), "4175.31")
+                self.assertRegex(cfdi.get("Total"), r"^\d+\.\d{2}$")
+                total = float(cfdi.get("Total"))
+                self.assertGreater(total, 0.0)
+
+        self._test_cfdi_rounding(run)

--- a/l10n_mx_edi_decimal_fix/tests/test_decimal_fix.py
+++ b/l10n_mx_edi_decimal_fix/tests/test_decimal_fix.py
@@ -1,0 +1,243 @@
+from lxml import etree
+
+from odoo import Command
+from odoo.tests import tagged
+
+from .common import TestDecimalFixCommon
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestDecimalFix(TestDecimalFixCommon):
+    """
+    Tests for l10n_mx_edi_decimal_fix when the accounting currency has more than
+    2 decimal places.
+
+    Main case: qty=0.5, price_unit=83506.23 with MXN configured at 6 decimal places.
+    The raw multiplication gives 41753.115 whose float representation may be slightly
+    below the exact value.  float_round(..., precision_digits=2) would then produce
+    41753.11 instead of the correct ROUND_HALF_UP result of 41753.12, causing the PAC
+    to reject the CFDI due to arithmetic inconsistency.
+    """
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _get_cfdi_tree(self, document):
+        return etree.fromstring(document.attachment_id.raw)
+
+    def _get_invoice_document(self, invoice):
+        return invoice.l10n_mx_edi_invoice_document_ids.filtered(
+            lambda d: d.state == "invoice_sent"
+        )[:1]
+
+    def _get_payment_document(self, payment_move):
+        return payment_move.l10n_mx_edi_payment_document_ids.filtered(
+            lambda d: d.state == "payment_sent"
+        )[:1]
+
+    def _assert_comprobante_amounts(self, cfdi, subtotal, total, discount=None):
+        self.assertEqual(cfdi.get("SubTotal"), subtotal)
+        self.assertEqual(cfdi.get("Total"), total)
+        if discount is not None:
+            self.assertEqual(cfdi.get("Descuento"), discount)
+
+    def _assert_aggregate_traslado(self, cfdi, base, importe, tasa="0.160000"):
+        """Assert the aggregate cfdi:Impuestos/cfdi:Traslados/cfdi:Traslado node."""
+        ns = "http://www.sat.gob.mx/cfd/4"
+        traslados = cfdi.findall(
+            f"{{{ns}}}Impuestos/{{{ns}}}Traslados/{{{ns}}}Traslado"
+        )
+        self.assertTrue(traslados, "No aggregate Traslado found in CFDI")
+        traslado = traslados[0]
+        self.assertEqual(traslado.get("Base"), base)
+        self.assertEqual(traslado.get("Importe"), importe)
+        self.assertEqual(traslado.get("TasaOCuota"), tasa)
+
+    # -------------------------------------------------------------------------
+    # Case 1: MXN 6 decimals — qty=0.5, price=83,506.23 — no discount
+    # -------------------------------------------------------------------------
+
+    def test_half_up_rounding_subtotal(self):
+        """
+        SubTotal = 0.5 × 83506.23 = 41753.115 → ROUND_HALF_UP to 2 dp = 41753.12.
+        The bug was that float_round() rounded this to 41753.11 (HALF-EVEN or fp error),
+        while format_float() via Decimal correctly gives 41753.12.
+        """
+        with self.mx_external_setup(self.frozen_today):
+            invoice = self._create_invoice(
+                currency_id=self.mxn_currency.id,
+                invoice_line_ids=[
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 0.5,
+                            "price_unit": 83506.23,
+                            "tax_ids": [Command.set(self.tax_16.ids)],
+                        }
+                    ),
+                ],
+            )
+
+            with self.with_mocked_pac_sign_success():
+                invoice._l10n_mx_edi_cfdi_invoice_try_send()
+
+            document = self._get_invoice_document(invoice)
+            self.assertTrue(document, "CFDI invoice document was not created")
+
+            cfdi = self._get_cfdi_tree(document)
+            self._assert_comprobante_amounts(
+                cfdi, subtotal="41753.12", total="48433.62"
+            )
+            self._assert_aggregate_traslado(cfdi, base="41753.12", importe="6680.50")
+
+    # -------------------------------------------------------------------------
+    # Case 2: PPD payment after case 1 invoice
+    # -------------------------------------------------------------------------
+
+    def test_half_up_rounding_payment(self):
+        """
+        PPD payment for the 41753.12 + IVA invoice.
+        Validates ImpSaldoAnt, ImpPagado and ImpSaldoInsoluto are coherent at 2 dp.
+        """
+        with self.mx_external_setup(self.frozen_today):
+            invoice = self._create_invoice(
+                currency_id=self.mxn_currency.id,
+                invoice_line_ids=[
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 0.5,
+                            "price_unit": 83506.23,
+                            "tax_ids": [Command.set(self.tax_16.ids)],
+                        }
+                    ),
+                ],
+            )
+            with self.with_mocked_pac_sign_success():
+                invoice._l10n_mx_edi_cfdi_invoice_try_send()
+
+            invoice_doc = self._get_invoice_document(invoice)
+            self.assertTrue(invoice_doc)
+
+            payment = self._create_payment(invoice)
+            with self.with_mocked_pac_sign_success():
+                payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
+
+            pay_doc = self._get_payment_document(payment.move_id)
+            self.assertTrue(pay_doc, "CFDI payment document was not created")
+
+            pay_cfdi = self._get_cfdi_tree(pay_doc)
+            ns_pago = "http://www.sat.gob.mx/Pagos20"
+
+            docto_list = pay_cfdi.findall(f".//{{{ns_pago}}}DoctoRelacionado")
+            self.assertTrue(docto_list, "No DoctoRelacionado in payment CFDI")
+            docto = docto_list[0]
+            imp_saldo_ant = docto.get("ImpSaldoAnt")
+            imp_pagado = docto.get("ImpPagado")
+            imp_saldo_insoluto = docto.get("ImpSaldoInsoluto")
+
+            # After fixing the invoice CFDI, the stored invoice total is coherent
+            # and the payment complement must reflect the 2-decimal rounded amount.
+            self.assertEqual(imp_saldo_insoluto, "0.00")
+            self.assertEqual(imp_saldo_ant, imp_pagado)
+
+            # The paid amount must be positive and have at most 2 decimal places.
+            self.assertRegex(imp_pagado, r"^\d+\.\d{2}$")
+
+    # -------------------------------------------------------------------------
+    # Case 3: USD 6 decimals — same qty/price, payment in MXN
+    # -------------------------------------------------------------------------
+
+    def test_half_up_usd_multidivisa(self):
+        """
+        Invoice in USD (6 decimal places) for qty=0.5, price=83506.23.
+        Then a payment in MXN to validate the currency conversion path.
+        """
+        rate = 1.0 / 17.0  # 1 USD = 17 MXN
+        self.setup_rates(self.usd_currency, (self.frozen_today, rate))
+
+        with self.mx_external_setup(self.frozen_today):
+            invoice = self._create_invoice(
+                currency_id=self.usd_currency.id,
+                invoice_line_ids=[
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 0.5,
+                            "price_unit": 83506.23,
+                            "tax_ids": [Command.set(self.tax_16.ids)],
+                        }
+                    ),
+                ],
+            )
+            with self.with_mocked_pac_sign_success():
+                invoice._l10n_mx_edi_cfdi_invoice_try_send()
+
+            inv_doc = self._get_invoice_document(invoice)
+            self.assertTrue(
+                inv_doc, "CFDI invoice document was not created for USD invoice"
+            )
+
+            inv_cfdi = self._get_cfdi_tree(inv_doc)
+            self.assertEqual(inv_cfdi.get("Moneda"), "USD")
+            # SubTotal must be ROUND_HALF_UP of 41753.115 to 2 dp = 41753.12
+            self._assert_comprobante_amounts(
+                inv_cfdi, subtotal="41753.12", total="48433.62"
+            )
+
+        with self.mx_external_setup(self.frozen_today):
+            payment = self._create_payment(
+                invoice,
+                currency_id=self.mxn_currency.id,
+            )
+            with self.with_mocked_pac_sign_success():
+                payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
+
+            pay_doc = self._get_payment_document(payment.move_id)
+            self.assertTrue(
+                pay_doc, "CFDI payment document was not created for USD→MXN"
+            )
+
+    # -------------------------------------------------------------------------
+    # Case 4: MXN 6 decimals — same qty/price with 10% discount
+    # -------------------------------------------------------------------------
+
+    def test_half_up_rounding_with_discount(self):
+        """
+        10% discount on same line.
+        SubTotal (gross) = 41753.12, Descuento = 4175.31 (ROUND_HALF_UP of 4175.3115).
+        Validates that the Descuento attribute is correctly included and Total is
+        coherent.
+        """
+        with self.mx_external_setup(self.frozen_today):
+            invoice = self._create_invoice(
+                currency_id=self.mxn_currency.id,
+                invoice_line_ids=[
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 0.5,
+                            "price_unit": 83506.23,
+                            "discount": 10.0,
+                            "tax_ids": [Command.set(self.tax_16.ids)],
+                        }
+                    ),
+                ],
+            )
+            with self.with_mocked_pac_sign_success():
+                invoice._l10n_mx_edi_cfdi_invoice_try_send()
+
+            document = self._get_invoice_document(invoice)
+            self.assertTrue(document)
+
+            cfdi = self._get_cfdi_tree(document)
+            # SubTotal is gross (before discount) = ROUND_HALF_UP(41753.115) = 41753.12
+            self.assertEqual(cfdi.get("SubTotal"), "41753.12")
+            # Descuento = ROUND_HALF_UP(4175.3115) = 4175.31
+            self.assertEqual(cfdi.get("Descuento"), "4175.31")
+            # Total must be a valid 2-decimal number
+            self.assertRegex(cfdi.get("Total"), r"^\d+\.\d{2}$")
+            # Total = SubTotal - Descuento + IVA → must be positive
+            total = float(cfdi.get("Total"))
+            self.assertGreater(total, 0.0)


### PR DESCRIPTION
## Summary
- Replace `float_round()` with `format_float()` (Decimal ROUND_HALF_UP) for `SubTotal`, `Descuento`, `Total`, and aggregate `Traslado Base` in the CFDI template
- Fix platform-dependent IEEE 754 rounding error: `0.5 × 83,506.23 = 41753.115` could round to `41753.11` instead of `41753.12`, causing PAC rejection
- Add unit tests covering: main rounding case, PPD payment complement, USD multidivisa, and discount scenarios

## Test plan
- [ ] `test_half_up_rounding_subtotal` — SubTotal=41753.12, Total=48433.62 with qty=0.5, price=83506.23, MXN 6dp
- [ ] `test_half_up_rounding_payment` — PPD payment ImpSaldoInsoluto=0.00, ImpSaldoAnt==ImpPagado
- [ ] `test_half_up_usd_multidivisa` — USD invoice (6dp) + MXN payment, correct SubTotal
- [ ] `test_half_up_rounding_with_discount` — 10% discount, Descuento=4175.31, SubTotal=41753.12