### PR TITLE
[FIX] l10n_mx_edi_decimal_fix: format TrasladoDR BaseDR/ImporteDR to 6dp to match BaseP and prevent SAT rejection

### DIFF
--- a/l10n_mx_edi_decimal_fix/__manifest__.py
+++ b/l10n_mx_edi_decimal_fix/__manifest__.py
@@ -1,13 +1,13 @@
 {
     "name": "MX EDI Decimal Fix",
-    "version": "17.0.1.0.6",
+    "version": "17.0.1.0.7",
     "summary": "Fix EDI Documents when decimal precision of currency is greater than 2",
     "author": "Jarsa",
     "website": "https://github.com/amxodoo/enterprise",
     "license": "LGPL-3",
     "category": "Localization/Mexico",
     "depends": [
-        "l10n_mx_edi",
+        "l10n_mx_edi_extended",
     ],
     "data": [
         "data/cfdi.xml",

--- a/l10n_mx_edi_decimal_fix/data/payment.xml
+++ b/l10n_mx_edi_decimal_fix/data/payment.xml
@@ -156,6 +156,20 @@
 
         </xpath>
 
+        <!-- TrasladoDR: format BaseDR/ImporteDR to 6dp so SAT validation
+             BaseP == sum(BaseDR/EquivalenciaDR) holds at 6dp precision -->
+        <xpath
+            expr="//*[local-name()='TrasladoDR' and namespace-uri()='http://www.sat.gob.mx/Pagos20']"
+            position="attributes"
+        >
+            <attribute
+                name="t-att-BaseDR"
+            >invoice_values['format_float'](tax_values['base'], precision=6)</attribute>
+            <attribute
+                name="t-att-ImporteDR"
+            >invoice_values['format_float'](tax_values['importe'], precision=6)</attribute>
+        </xpath>
+
         <xpath
             expr="//*[local-name()='TrasladoP' and namespace-uri()='http://www.sat.gob.mx/Pagos20']"
             position="attributes"
@@ -166,6 +180,9 @@
                         float(format_float(traslado['base'], precision=6)) / float(format_float(docto['equivalencia'], precision=10) or '1')
                         for docto in docto_relationado_list
                         for traslado in docto['traslados_list']
+                        if traslado['impuesto'] == tax_values['impuesto']
+                        and traslado['tipo_factor'] == tax_values['tipo_factor']
+                        and traslado['tasa_o_cuota'] == tax_values['tasa_o_cuota']
                     ),
                     precision=6
                 )
@@ -176,6 +193,9 @@
                         float(format_float(traslado['importe'], precision=6)) / float(format_float(docto['equivalencia'], precision=10) or '1')
                         for docto in docto_relationado_list
                         for traslado in docto['traslados_list']
+                        if traslado['impuesto'] == tax_values['impuesto']
+                        and traslado['tipo_factor'] == tax_values['tipo_factor']
+                        and traslado['tasa_o_cuota'] == tax_values['tasa_o_cuota']
                     ),
                     precision=6
                 )

--- a/l10n_mx_edi_decimal_fix/models/l10n_mx_edi_document.py
+++ b/l10n_mx_edi_decimal_fix/models/l10n_mx_edi_document.py
@@ -40,8 +40,8 @@ class L10nMxEdiDocument(models.Model):
         d_tax = Decimal(str(tax_amount))
         d_rate = Decimal(str(tax_rate))
 
-        mismatch = (d_base * d_rate - d_tax).copy_abs().quantize(
-            qty, rounding=ROUND_DOWN
+        mismatch = (
+            (d_base * d_rate - d_tax).copy_abs().quantize(qty, rounding=ROUND_DOWN)
         )
         if mismatch == Decimal("0"):
             # No arithmetic inconsistency at precision_digits — return values
@@ -74,8 +74,11 @@ class L10nMxEdiDocument(models.Model):
             move = self.env["account.move"].browse(
                 self._context.get("params", {}).get("id")
             )
-            if move and move.journal_id.l10n_mx_address_issued_id != res.get(
-                "issued_address"
+            if (
+                move
+                and move.journal_id.l10n_mx_address_issued_id
+                and move.journal_id.l10n_mx_address_issued_id
+                != res.get("issued_address")
             ):
                 res["issued_address"] = move.journal_id.l10n_mx_address_issued_id
         return res

--- a/l10n_mx_edi_decimal_fix/tests/test_decimal_fix.py
+++ b/l10n_mx_edi_decimal_fix/tests/test_decimal_fix.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from lxml import etree
 
 from odoo import Command
@@ -262,5 +264,101 @@ class TestDecimalFix(TestDecimalFixCommon):
                 self.assertRegex(cfdi.get("Total"), r"^\d+\.\d{2}$")
                 total = float(cfdi.get("Total"))
                 self.assertGreater(total, 0.0)
+
+        self._test_cfdi_rounding(run)
+
+    # -------------------------------------------------------------------------
+    # Case 5: BaseDR / BaseP consistency at 6dp — SAT validation rule
+    # -------------------------------------------------------------------------
+
+    def test_traslado_dr_base_p_consistency(self):
+        """
+        USD invoice with a price that yields a base with more than 2 decimal
+        places when stored with 6dp precision (e.g. 500.001).
+
+        Root cause: the original payment20 template formats BaseDR to 2dp while
+        BaseP already uses 6dp.  With 6dp accounting the values can diverge:
+          BaseDR = "500.00"  (2dp)
+          BaseP  = "500.001000"  (6dp)
+        SAT rejects with:
+          "El campo BaseP... no es igual a la suma de los importes de las bases
+           registrados en los documentos relacionados..."
+
+        Fix: TrasladoDR is overridden to use 6dp so both sides match exactly.
+        Tested for both round_per_line and round_globally.
+        """
+        rate = 1.0 / 17.0
+        self.setup_rates(self.usd_currency, (self.frozen_today, rate))
+
+        def run(rounding_method):
+            with self.mx_external_setup(self.frozen_today):
+                invoice = self._create_invoice(
+                    currency_id=self.usd_currency.id,
+                    invoice_line_ids=[
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 1,
+                                "price_unit": 500.001,
+                                "tax_ids": [Command.set(self.tax_16.ids)],
+                            }
+                        ),
+                    ],
+                )
+                with self.with_mocked_pac_sign_success():
+                    invoice._l10n_mx_edi_cfdi_invoice_try_send()
+
+                payment = self._create_payment(
+                    invoice, currency_id=self.usd_currency.id
+                )
+                with self.with_mocked_pac_sign_success():
+                    payment.move_id._l10n_mx_edi_cfdi_payment_try_send()
+
+                pay_doc = self._get_payment_document(payment.move_id)
+                self.assertTrue(
+                    pay_doc,
+                    f"No payment document created ({rounding_method})",
+                )
+
+                pay_cfdi = self._get_cfdi_tree(pay_doc)
+                ns_pago = "http://www.sat.gob.mx/Pagos20"
+
+                # Collect BaseDR values per DoctoRelacionado and verify 6dp.
+                docto_list = pay_cfdi.findall(f".//{{{ns_pago}}}DoctoRelacionado")
+                self.assertTrue(
+                    docto_list, f"No DoctoRelacionado found ({rounding_method})"
+                )
+                base_dr_total = Decimal("0")
+                for docto in docto_list:
+                    equivalencia = Decimal(docto.get("EquivalenciaDR") or "1")
+                    traslados_dr = docto.findall(
+                        f"{{{ns_pago}}}ImpuestosDR"
+                        f"/{{{ns_pago}}}TrasladosDR"
+                        f"/{{{ns_pago}}}TrasladoDR"
+                    )
+                    for tdr in traslados_dr:
+                        base_dr_str = tdr.get("BaseDR", "0")
+                        self.assertRegex(
+                            base_dr_str,
+                            r"^\d+\.\d{6}$",
+                            f"BaseDR must have 6 decimal places ({rounding_method})",
+                        )
+                        base_dr_total += Decimal(base_dr_str) / equivalencia
+
+                # BaseP must equal sum(BaseDR / EquivalenciaDR) exactly at 6dp.
+                traslados_p = pay_cfdi.findall(f".//{{{ns_pago}}}TrasladoP")
+                self.assertTrue(traslados_p, f"No TrasladoP found ({rounding_method})")
+                for tp in traslados_p:
+                    base_p_str = tp.get("BaseP", "0")
+                    self.assertRegex(
+                        base_p_str,
+                        r"^\d+\.\d{6}$",
+                        f"BaseP must have 6 decimal places ({rounding_method})",
+                    )
+                    self.assertEqual(
+                        Decimal(base_p_str),
+                        base_dr_total,
+                        f"BaseP must equal sum(BaseDR/EquivalenciaDR) ({rounding_method})",
+                    )
 
         self._test_cfdi_rounding(run)


### PR DESCRIPTION
 task#31174