### PR TITLE
[FIX] l10n_mx_reports_fix_diot: compute DIOT VAT from rounded base task#30993

### DIFF
--- a/l10n_mx_reports_fix_diot/__manifest__.py
+++ b/l10n_mx_reports_fix_diot/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Fix DIOT Report Values",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Report",
     "author": "Jarsa",
     "website": "https://github.com/amxodoo/enterprise",

--- a/l10n_mx_reports_fix_diot/models/account_diot.py
+++ b/l10n_mx_reports_fix_diot/models/account_diot.py
@@ -1,9 +1,34 @@
-from odoo import models
 import math
+
+from odoo import models
+
+
+# SAT rounding rule: decimals <= .50 go down, > .50 go up.
+def sat_round(value):
+    decimal = round(value - math.floor(value), 2)
+    return math.floor(value) if decimal <= 0.50 else math.ceil(value)
+
+
+# SAT validates every VAT column against the already-rounded base, so the VAT
+# must be recomputed as rounded_base * rate instead of rounding the VAT coming
+# from accounting (e.g. base 5,006.42 -> 5,006; 5,006 * 0.08 = 400.48 -> 400,
+# while rounding the accounting VAT 400.51 would wrongly report 401).
+TAX_BASE_RATE = {
+    "paid_8_tax": ("paid_8", 0.08),
+    "paid_8_non_cred_tax": ("paid_8_non_cred", 0.08),
+    "paid_8_s_tax": ("paid_8_s", 0.08),
+    "paid_8_s_nc_tax": ("paid_8_s_nc", 0.08),
+    "paid_16_tax": ("paid_16", 0.16),
+    "paid_16_non_cred_tax": ("paid_16_non_cred", 0.16),
+    "importation_16_tax": ("importation_16", 0.16),
+    "paid_16_imp_nc_tax": ("paid_16_imp_nc", 0.16),
+    "paid_16_imp_int_tax": ("paid_16_imp_int", 0.16),
+    "paid_16_imp_int_nc_tax": ("paid_16_imp_int_nc", 0.16),
+}
 
 
 class MexicanAccountReportCustomHandler(models.AbstractModel):
-    _inherit = 'l10n_mx.report.handler'
+    _inherit = "l10n_mx.report.handler"
 
     def l10n_mx_diot_get_values(self, values, data, partner):
         res = super().l10n_mx_diot_get_values(values, data, partner)
@@ -26,12 +51,26 @@ class MexicanAccountReportCustomHandler(models.AbstractModel):
 
     def _get_diot_values_per_partner(self, report, options):
         diot_values = super()._get_diot_values_per_partner(report, options)
-        for partner, data in diot_values.items():
+        for data in diot_values.values():
+            originals = dict(data)
             for label, value in data.items():
                 if value and isinstance(value, float):
-                    decimal = round(value - math.floor(value), 2)
-                    if decimal <= 0.50:
-                        diot_values[partner][label] = math.floor(value)
-                    else:
-                        diot_values[partner][label] = math.ceil(value)
+                    data[label] = sat_round(value)
+            for tax_label, (base_label, rate) in TAX_BASE_RATE.items():
+                tax = originals.get(tax_label)
+                base = originals.get(base_label)
+                if (
+                    not tax
+                    or not base
+                    or not isinstance(tax, float)
+                    or not isinstance(base, float)
+                ):
+                    continue
+                # Recompute only when the accounting VAT already matches
+                # base * rate up to per-invoice cent drift; with partially
+                # creditable VAT the accounting amount must be kept as is.
+                # ponytail: 0.5 tolerance covers ~100 invoices of half-cent
+                # drift per partner; raise it if a partner ever exceeds that.
+                if abs(base * rate - tax) <= 0.5:
+                    data[tax_label] = sat_round(sat_round(base) * rate)
         return diot_values


### PR DESCRIPTION
## Problem

MTNMX (task#30993) keeps getting DIOT TXT rejections. The SAT validator computes each VAT column from the **already-rounded base**, so rounding the accounting VAT can differ by one peso:

- base 5,006.42 → rounded to 5,006
- SAT expects: 5,006 × 0.08 = 400.48 → **400**
- current module reports: accounting VAT 400.51 → **401** → rejected

## Fix

After applying the SAT rounding rule (≤ .50 down, > .50 up) to every column, recompute each VAT column as `sat_round(sat_round(base) × rate)` — but **only when the accounting VAT already matches base × rate within cent drift (0.5 tolerance)**. Partners with partially creditable VAT (real cases in the DB: effective rates of 0.002%–13%) keep their accounting amount untouched, since forcing base × rate would misstate the declaration by thousands of pesos.

## Validation

Ran read-only against the MTNMX staging DB for Jan–Jul 2026 via `odoo-bin shell`:

- The reported case (ALQUILADORA, Jan) now exports 400 instead of 401.
- 7–24 VAT cells corrected per month (cent drift in both directions).
- 6–14 partially-creditable partners per month correctly left untouched.
- One data issue surfaced (SONIC BUM, June: non-creditable VAT exceeds base × 16%) — accounting data problem, reported to the client separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)